### PR TITLE
Implement s3 backend storage

### DIFF
--- a/herbridge/herbridge/settings.py
+++ b/herbridge/herbridge/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'imagekit',
     'main',
+    'storages',
 ]
 
 MIDDLEWARE = [
@@ -145,6 +146,27 @@ FIXTURES_TO_LOAD = (
     'resources.json',
     'reports.json',
 )
+
+## configuration for S3 media storage
+## please copy these settings to local_settings.py and update
+## AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_STORAGE_BUCKET_NAME
+
+# AWS_ACCESS_KEY_ID = 'xxxx'
+# AWS_SECRET_ACCESS_KEY = 'xxxx'
+
+# AWS_STORAGE_BUCKET_NAME = 'xxxx'
+# AWS_S3_CUSTOM_DOMAIN = f'{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com'
+
+# AWS_S3_OBJECT_PARAMETERS = {
+    # 'CacheControl': 'max-age=86400',
+# }
+
+# AWS_LOCATION = 'static'
+# STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+# STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{AWS_LOCATION}/"
+
+# DEFAULT_FILE_STORAGE = 'herbridge.storage_backends.MediaStorage'
+# MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/media/"
 
 try:
     from herbridge.local_settings import *

--- a/herbridge/herbridge/storage_backends.py
+++ b/herbridge/herbridge/storage_backends.py
@@ -1,0 +1,5 @@
+from storages.backends.s3boto3 import S3Boto3Storage
+
+class MediaStorage(S3Boto3Storage):
+    location = 'media'
+    file_overwrite = False

--- a/herbridge/main/models/image.py
+++ b/herbridge/main/models/image.py
@@ -1,5 +1,6 @@
 import os
 from django.contrib.gis.db import models
+from django.db.models.signals import post_delete
 from PIL import Image as PILImage
 from io import BytesIO
 from imagekit.models import ImageSpecField
@@ -169,3 +170,9 @@ class Image(models.Model):
         }
 
         return data
+
+## explicitly handle file deletion, works locally and for S3
+def delete_file(sender, instance, **kwargs):
+    instance.image.delete(save=False)
+    
+post_delete.connect(delete_file, sender=Image)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ psycopg2==2.7.5
 Pillow==5.2.0
 djangorestframework==3.8.2
 django-imagekit==4.0.2
+boto3==1.7
+django-storages==1.6
 
 ## it's likely this requirement can go away, once we are sure that we won't be
 ## reading exif tags for photo location or date or orientation.


### PR DESCRIPTION
After this is merged, you can add all of the new variables in `settings.py` to your `local_settings.py` file (update the AWS credentials as necessary) and all of your media (image uploads) and static files (js,css) will be stored in the S3 bucket that you designate.

This is the preferred production configuration, and the result is:

1) for static files to be served correctly, you must run `python manage.py collectstatic` to get them copied to S3 into <bucket-name>/static/
2) posted media image will be saved to S3 in <bucket-name>/media/images/

However, this configuration may not be ideal for development, so you can keep all of the new settings out of `local_settings.py` (or put them in and then comment them out) and the app will run locally as before:

1) static files are served from their existing location in the app by django automatically (assuming you're using the django dev server)
2) "uploaded" images will be placed in the `media/images` directory.