### PR TITLE
Fix milliseconds since 1970 issue on the front end

### DIFF
--- a/herbridge/frontend/src/components/PhotoConfirmation/PhotoConfirmationInfo.js
+++ b/herbridge/frontend/src/components/PhotoConfirmation/PhotoConfirmationInfo.js
@@ -37,7 +37,7 @@ export default class extends React.Component {
     const { image } = this.props
     return (
       <List style={{ padding: '0 32px' }}>
-        { this.getListItem("Captured", moment(image.captureDate/1000).format("D MMMM YYYY [at] h:mm a")) }
+        { this.getListItem("Captured", moment(image.captureDate*1000).format("D MMMM YYYY [at] h:mm a")) }
         <Divider/>
         { this.getListItem("Location", `${image.latitude}, ${image.longitude}`) }
         <Divider/>

--- a/herbridge/frontend/src/components/PhotoConfirmation/PhotoConfirmationInfo.js
+++ b/herbridge/frontend/src/components/PhotoConfirmation/PhotoConfirmationInfo.js
@@ -37,7 +37,7 @@ export default class extends React.Component {
     const { image } = this.props
     return (
       <List style={{ padding: '0 32px' }}>
-        { this.getListItem("Captured", moment(image.captureDate).format("D MMMM YYYY [at] h:mm a")) }
+        { this.getListItem("Captured", moment(image.captureDate/1000).format("D MMMM YYYY [at] h:mm a")) }
         <Divider/>
         { this.getListItem("Location", `${image.latitude}, ${image.longitude}`) }
         <Divider/>

--- a/herbridge/frontend/src/lib/image.js
+++ b/herbridge/frontend/src/lib/image.js
@@ -4,7 +4,7 @@ const imageSectionsFromImages = (images) => {
   let sections = {}
   for (let i = 0; i < images.length; i++) {
     const image = images[i]
-    const date = moment(image.captureDate).startOf('day').toISOString()
+    const date = moment(image.captureDate/1000).startOf('day').toISOString()
     if (date in sections) {
       const section = sections[date]
       section.push(image)

--- a/herbridge/frontend/src/lib/image.js
+++ b/herbridge/frontend/src/lib/image.js
@@ -4,7 +4,7 @@ const imageSectionsFromImages = (images) => {
   let sections = {}
   for (let i = 0; i < images.length; i++) {
     const image = images[i]
-    const date = moment(image.captureDate/1000).startOf('day').toISOString()
+    const date = moment(image.captureDate*1000).startOf('day').toISOString()
     if (date in sections) {
       const section = sections[date]
       section.push(image)


### PR DESCRIPTION
The issue here was that the ios app and the api both expected decimal seconds since 1970, and the react app was expecting milliseconds since 1970. This PR fixes those assumptions.